### PR TITLE
Parent Node Check if item removed.

### DIFF
--- a/dist/dropzone.js
+++ b/dist/dropzone.js
@@ -628,7 +628,9 @@ module.exports = Icon;
         var _ref;
         if (file.previewElement) {
           if ((_ref = file.previewElement) != null) {
-            _ref.parentNode.removeChild(file.previewElement);
+            if (_ref.parentNode) {
+              _ref.parentNode.removeChild( file.previewElement );
+            }
           }
         }
         return this._updateMaxFilesReachedClass();


### PR DESCRIPTION
Use Case:

While using a dropzone wherein you just want to upload a file instantly and only one at a time, someone drags three files into dropzone.  From there you hit maxFilesReached and decide to process it manually and remove the rest of the files.  The files get removed but references from the queue still exist and thus the parent node complains.

```
handleMaxFilesReached () {
    this.processQueue();
    this.removeAllFiles();
}
```
